### PR TITLE
PMGR-10733 Use generic version of sfdxurl command flags

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function createAuthFile(){
 }
 
 function authSFDX(){
-  var params = '--setdefaultdevhubusername --setdefaultusername -a SFDX-ENV'
+  var params = '-d -s -a SFDX-ENV'
   exec('sfdx/bin/sfdx auth:sfdxurl:store -f /tmp/sfdx_auth.txt '+params, function(error, stdout, stderr){
     if(error) throw(stderr)
 	core.info(stdout)


### PR DESCRIPTION
`setdefaultdevhubusername` is turning into `set-default-dev-hub` and `setdefaultusername` is turning into `set-default`, however they haven't provided any overlap or backwards compatibility between the releases, so if I switch to the new usages our current scratch org builds on `sfdx stable` will start failing. So while I do tend to prefer the longer flag names so the reader more easily knows what the command is doing, I decided to just go with the short names of `-d` and `-s` since those are consistent between the two release and also seemingly less likely to change with any future naming whims.