### PR TITLE
PMGR-10732 Bumps node version to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: Supply a URL to a XZip'd tarball containing the version of the SFDX CLI to install. If omitted or blank, it will install the "latest" CLI
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'
 branding:
   icon: 'terminal'  


### PR DESCRIPTION
Our fork has diverged a bit from sfdx-actions, however before trying to merge those few changes into our fork I tried changing just the node version and nothing else to see if that was sufficient, and it appears to work fine in my test builds. Do we care about bringing in any other changes besides that? None of them seem particularly functional but rather just just file path changes, and apparently they aren't necessary changes for the thing to work?

https://github.com/patronmanager/setup-sfdx/compare/master...sfdx-actions:setup-sfdx:master